### PR TITLE
Setup YARD and document APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 /.bundle/
-/.yardoc
 /Gemfile.lock
-/_yardoc/
 /coverage/
 /doc/
 /pkg/
@@ -10,3 +8,7 @@
 
 # rspec failure tracking
 .rspec_status
+
+# YARD
+/.yardoc
+/_yardoc/

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,3 @@
+--title Kingfisher
+--markup markdown
+lib/**/*.rb

--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,3 @@
---title Kingfisher
+--title "Kingfisher API Documentation"
 --markup markdown
 lib/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "yard", "~> 0.9.9", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,8 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec
+
+require "yard"
+require "yard/rake/yardoc_task"
+YARD::Rake::YardocTask.new(:doc)


### PR DESCRIPTION
- `rake doc` to generate api docs in doc/ folder
- added `.yardopts` file to config generated doc's `<title>`, use markdown for markup, where are source files to generate documents (`lib/**/*.rb`), see [.yardopts file docs](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md#_yardopts_Options_File)
- online doc available at http://www.rubydoc.info/github/kingfisherframework/kingfisher/master

<img width="1435" alt="screen shot 2017-07-23 at 16 31 04" src="https://user-images.githubusercontent.com/1000669/28497519-58d6acfc-6fc4-11e7-9a65-a6ae62d6e8d0.png">

- [x] Setup RDoc
- [ ] Document APIs

Fixes #1
